### PR TITLE
Use Toast Notifications Instead of Bootstrap's built-in alerts

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "bootstrap": "~3.3.4",
     "jquery": "~2.1.4",
     "dexie": "~1.0.4",
-    "eonasdan-bootstrap-datetimepicker": "~4.7.14"
+    "eonasdan-bootstrap-datetimepicker": "~4.7.14",
+    "bootstrap-notify": "~0.2.0"
   }
 }

--- a/css/app.css
+++ b/css/app.css
@@ -1,6 +1,6 @@
 /* Application Styles */
 body {
-  min-height: 2000px;
+  /* min-height: 2000px; */
   padding-top: 70px;
 }
 

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="bower_components/bootstrap-material-design/dist/css/ripples.min.css">
     <link rel="stylesheet" href="bower_components/bootstrap-material-design/dist/css/roboto.min.css">
     <link rel="stylesheet" href="bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css">
+    <link rel="stylesheet" href="bower_components/bootstrap-notify/css/bootstrap-notify.css"></link>
     <link rel="stylesheet" href="css/app.css">
     <!-- /CSS -->
     <!-- javascript files -->
@@ -27,6 +28,7 @@
     <script src="lib/list.js/dist/list.min.js"></script>
     <script src="bower_components/moment/min/moment.min.js"></script>
     <script src="bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
+    <script src="bower_components/bootstrap-notify/js/bootstrap-notify.js"></script>
     <!-- /Javascript -->
   </head>
   
@@ -105,6 +107,9 @@
       </div>
     </div>
     <div class="container">
+      <!-- Notifications -->
+      <div class="notifications top-right"></div>
+      <!-- /Notifications -->
       <!-- Options Dialog -->
       <div id="options-dialog" class="modal fade" tabindex="-1">
         <div class="modal-dialog">
@@ -130,13 +135,6 @@
         </div>
       </div>
       <!-- /Options Dialog -->
-      <!-- Warning -->
-      <div class="alert alert-dismissable alert-warning" id="warning-alert">
-        <button type="button" class="close" data-dismiss="alert">×</button>
-        <h4>Warning!</h4>
-        <p>Looks like you may have left some fields blank when adding a new task.</p>
-      </div>
-      <!-- /Warning -->
       <!-- Task Table -->
       <div id="tasks">
         <table class="table table-hover table-bordered text-center">

--- a/index.html
+++ b/index.html
@@ -15,8 +15,7 @@
     <link rel="stylesheet" href="bower_components/bootstrap-material-design/dist/css/material-fullpalette.min.css">
     <link rel="stylesheet" href="bower_components/bootstrap-material-design/dist/css/ripples.min.css">
     <link rel="stylesheet" href="bower_components/bootstrap-material-design/dist/css/roboto.min.css">
-    <link rel="stylesheet" href="bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css"
-    />
+    <link rel="stylesheet" href="bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css">
     <link rel="stylesheet" href="css/app.css">
     <!-- /CSS -->
     <!-- javascript files -->

--- a/js/app.js
+++ b/js/app.js
@@ -21,17 +21,19 @@ $(function () {
     });
 
     $('#dueDatePicker').datetimepicker();
-    $('#warning-alert').hide();
     $('#editTask-Btn').hide();
 
     // setup click handler for add task button
     $('#addTask-Btn').click(function () {
       // prevent Fields from being blank
       if ($.trim($('#subject').val()) === "" || $.trim($('#title').val()) === "" || $.trim($('#dueDate').val()) === "") {
-        $('#warning-alert').fadeIn();
+        // show toast notification warning when user doesn't fill all text fields
+        $('.notifications.top-right').notify({
+          type: "warning",
+          message: {text: "You left some fields blank when trying to add a task. " }
+        }).show();
         return;
       }
-      $('#warning-alert').fadeOut();
 
       var task = {
         subject: $('#subject').val(),


### PR DESCRIPTION
Bootstraps alerts are not very good as it requires HTML/JS and so I had to sit there and make sure to hide and show them. WIth Bootstrap-notify it is much better and easier to re-use code since you can change the message from JS.
I also removed the minimum height from css since it was kind of silly to have.
